### PR TITLE
Update webpack.server.development.js

### DIFF
--- a/webpack/webpack.server.development.js
+++ b/webpack/webpack.server.development.js
@@ -1,6 +1,6 @@
 const WebpackBar = require('webpackbar');
 const merge = require('webpack-merge');
-
+const webpack = require('webpack');
 const { server } = require('./common');
 
 module.exports = merge(server, {
@@ -8,5 +8,11 @@ module.exports = merge(server, {
   output: {
     filename: '[name].js'
   },
-  plugins: [new WebpackBar({ name: 'server' })]
+  plugins: [new WebpackBar({ name: 'server' }),
+      new webpack.SourceMapDevToolPlugin({
+        filename: "[file].map",
+        fallbackModuleFilenameTemplate: '[absolute-resource-path]',
+        moduleFilenameTemplate: '[absolute-resource-path]'
+      })
+  ]
 });


### PR DESCRIPTION
Added config to use absolute-resource-path for sourcemaps which will allow VSCode to attach debugger to it, if you run yarn start from a javascript debug window in terminal inside vscode